### PR TITLE
fixed bugs in FastAtomicAdd directory

### DIFF
--- a/FastAtomicAdd/atomic_add_half.cu
+++ b/FastAtomicAdd/atomic_add_half.cu
@@ -37,7 +37,7 @@ int main(){
     half *output_host = (half*)malloc(sizeof(half));
     half *output_device;
     cudaMalloc((void **)&output_device, sizeof(half));
-    cudaMemset(&output_device, 0, sizeof(half));
+    cudaMemset(output_device, 0, sizeof(half));
 
     int32_t block_num = (N + kBlockSize - 1) / kBlockSize;
     dim3 grid(block_num, 1);

--- a/FastAtomicAdd/atomic_add_half_pack2.cu
+++ b/FastAtomicAdd/atomic_add_half_pack2.cu
@@ -50,21 +50,21 @@ int main(){
     half *x_host = (half*)malloc(N*sizeof(half));
     half *x_device;
     cudaMalloc((void **)&x_device, N*sizeof(half));
-    for (int i = 0; i < N; i++) x_host[i] = 1.0;
+    for (int i = 0; i < N; i++) x_host[i] = 0.1;
     cudaMemcpy(x_device, x_host, N*sizeof(half), cudaMemcpyHostToDevice);
     Pack<half, 2>* x_pack = reinterpret_cast<Pack<half, 2>*>(x_device);
 
     half *y_host = (half*)malloc(N*sizeof(half));
     half *y_device;
     cudaMalloc((void **)&y_device, N*sizeof(half));
-    for (int i = 0; i < N; i++) y_host[i] = 1.0;
+    for (int i = 0; i < N; i++) y_host[i] = 0.1;
     cudaMemcpy(y_device, y_host, N*sizeof(half), cudaMemcpyHostToDevice);
     Pack<half, 2>* y_pack = reinterpret_cast<Pack<half, 2>*>(y_device);
 
     half *output_host = (half*)malloc(2 * sizeof(half));
     half *output_device;
     cudaMalloc((void **)&output_device, 2 * sizeof(half));
-    cudaMemset(&output_device, 0, sizeof(half) * 2);
+    cudaMemset(output_device, 0, sizeof(half) * 2);
     Pack<half, 2>* output_pack = reinterpret_cast<Pack<half, 2>*>(output_device);
 
     int32_t block_num = (N + kBlockSize - 1) / kBlockSize;

--- a/FastAtomicAdd/fast_atomic_add_half.cu
+++ b/FastAtomicAdd/fast_atomic_add_half.cu
@@ -63,7 +63,7 @@ __global__ void dot(half* a, half* b, half* c, int n){
         gid += nStep;
     }
     // atomicAdd(c, temp);
-    FastAdd(c, 0, N, temp);
+    FastAdd(c, 0, 2, temp);
 }
 
 int main(){
@@ -79,16 +79,16 @@ int main(){
     for (int i = 0; i < N; i++) y_host[i] = 0.1;
     cudaMemcpy(y_device, y_host, N*sizeof(half), cudaMemcpyHostToDevice);
 
-    half *output_host = (half*)malloc(sizeof(half));
+    half *output_host = (half*)malloc(sizeof(half) * 2);
     half *output_device;
-    cudaMalloc((void **)&output_device, sizeof(half));
-    cudaMemset(&output_device, 0, sizeof(half));
+    cudaMalloc((void **)&output_device, sizeof(half) * 2);
+    cudaMemset(output_device, 0, sizeof(half) * 2);
 
     int32_t block_num = (N + kBlockSize - 1) / kBlockSize;
     dim3 grid(block_num, 1);
     dim3 block(kBlockSize, 1);
     dot<<<grid, block>>>(x_device, y_device, output_device, N);
-    cudaMemcpy(output_host, output_device, sizeof(half), cudaMemcpyDeviceToHost);
+    cudaMemcpy(output_host, output_device, sizeof(half) * 2, cudaMemcpyDeviceToHost);
     printf("%.6f\n", static_cast<double>(output_host[0]));
     free(x_host);
     free(y_host);


### PR DESCRIPTION
Fixed bugs in FastAtomicAdd directory:  
1. remove `&`  in front of parameter `output_device` of `cudaMemset()`  at `main()` of three cuda files
2. In `fast_atomic_add_half.cu` file, the size of `output_device` should be `sizeof(half) * 2`, and the third parameter of `FastAdd()` in `dot()` should be `2` instead of `N`.
**Reason**: According to the implementation of the `FastSpecializedAtomicAdd()` function, I think that the `length` parameter should refer to the length of the `base` array. Therefore, it should not be `N`. And if we want to use the `atomicAdd()` implementation with `half2`, we need to ensure that `output_device` is allocated with at least 2 halves in size.  
You can use the `compute-sanitizer --launch-timeout=0 --tool=memcheck ./bin/fast_atomic_add_half > opt.txt 2>&1` command to check the original implementation for triggering out-of-bounds access errors.  
3. By the way, in `atomic_add_half_pack2.cu` file, I changed the initial values of elements in  `x_host` and `y_host` from `1.0` to `0.1` to match the initial values in the `atomic_add_half.cu` and `fast_atomic_add_half.cu` files.